### PR TITLE
Test dependency review

### DIFF
--- a/services/flask/requirements.txt
+++ b/services/flask/requirements.txt
@@ -2,7 +2,7 @@ Flask~=2.2.2
 Flask-Session~=0.4.0
 gunicorn~=20.1.0
 numpy~=1.23.3
-opencv-python-headless~=4.6.0.66
+opencv-python-headless~=4.0.0.21
 requests~=2.28.1
 
 # Testing requirements

--- a/services/flask/requirements.txt
+++ b/services/flask/requirements.txt
@@ -2,7 +2,7 @@ Flask~=2.2.2
 Flask-Session~=0.4.0
 gunicorn~=20.1.0
 numpy~=1.23.3
-opencv-python-headless~=4.0.0.21
+opencv-python-headless~=4.5.5.64
 requests~=2.28.1
 
 # Testing requirements


### PR DESCRIPTION
Test dependency review by bumping down `opencv-python-headless`.